### PR TITLE
Add CLI wrapper for freenove sketch

### DIFF
--- a/CodexEnvironment
+++ b/CodexEnvironment
@@ -74,4 +74,4 @@ retry 5 5 arduino-cli lib install "ArduinoJson"
 retry 5 5 arduino-cli lib install "TFT_eSPI"
 
 echo "✅ Setup complete. Compile with:"
-echo "   arduino-cli compile --fqbn esp32:esp32:esp32 freenove.ino"
+echo "   arduino-cli compile --fqbn esp32:esp32:esp32 sketches/freenove"

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ retry 5 5 arduino-cli lib install "ArduinoJson"
 retry 5 5 arduino-cli lib install "TFT_eSPI"
 
 echo "✅ Setup complete. Compile with:"
-echo "   arduino-cli compile --fqbn esp32:esp32:esp32 freenove.ino"
+echo "   arduino-cli compile --fqbn esp32:esp32:esp32 sketches/freenove"
 ```
 
-The command completes successfully when the required libraries (`ArduinoJson`, `TFT_eSPI`, etc.) are installed.
+The command completes successfully when the required libraries (`ArduinoJson`, `TFT_eSPI`, etc.) are installed. A thin wrapper
+sketch lives in `sketches/freenove` so that `arduino-cli` sees a folder/file pair with matching names while still keeping the
+primary source at the repository root for IDE users.
 
 

--- a/sketches/freenove/freenove.ino
+++ b/sketches/freenove/freenove.ino
@@ -1,0 +1,3 @@
+// Wrapper sketch so arduino-cli sees a folder/file pair with matching names.
+// This allows compiling the original freenove.ino without relocating it.
+#include "../../freenove.ino"


### PR DESCRIPTION
## Summary
- add a wrapper sketch under sketches/freenove so arduino-cli finds a matching folder/file pair
- document the new compile path in README and CodexEnvironment instructions

## Testing
- arduino-cli compile --fqbn esp32:esp32:esp32 sketches/freenove

------
https://chatgpt.com/codex/tasks/task_e_68cc2a5e682c832688252ee8b0c8ecab