### PR TITLE
Adjust radar layout and streamline display

### DIFF
--- a/freenove.ino
+++ b/freenove.ino
@@ -184,52 +184,30 @@ void updateDisplay() {
     }
     drawInfoLine(lineIndex++, header);
 
-    String distanceLine = String(closestAircraft.distanceKm, 1) + " km  " + formatBearingString(closestAircraft.bearing);
-    drawInfoLine(lineIndex++, distanceLine);
+    drawInfoLine(lineIndex++, "Distance: " + String(closestAircraft.distanceKm, 1) + " km");
 
-    String detailLine;
     if (closestAircraft.altitude >= 0) {
-      detailLine += String(closestAircraft.altitude) + " ft";
+      drawInfoLine(lineIndex++, "Altitude: " + String(closestAircraft.altitude) + " ft");
     }
+
     if (!isnan(closestAircraft.groundSpeed) && closestAircraft.groundSpeed >= 0) {
-      if (detailLine.length()) {
-        detailLine += "  ";
-      }
-      detailLine += String(closestAircraft.groundSpeed, 0) + " kt";
+      drawInfoLine(lineIndex++, "Speed: " + String(closestAircraft.groundSpeed, 0) + " kt");
     }
-    if (closestAircraft.inbound) {
-      if (!isnan(closestAircraft.minutesToClosest) && closestAircraft.minutesToClosest >= 0) {
-        if (detailLine.length()) {
-          detailLine += "  ";
-        }
-        detailLine += String(closestAircraft.minutesToClosest, 1) + " min";
-      }
-    } else if (!isnan(closestAircraft.track)) {
-      if (detailLine.length()) {
-        detailLine += "  ";
-      }
-      detailLine += formatBearingString(closestAircraft.track);
+
+    if (closestAircraft.inbound && !isnan(closestAircraft.minutesToClosest) && closestAircraft.minutesToClosest >= 0) {
+      drawInfoLine(lineIndex++, "ETA: " + String(closestAircraft.minutesToClosest, 1) + " min");
     }
-    drawInfoLine(lineIndex++, detailLine);
   } else {
     drawInfoLine(lineIndex++, "No aircraft in range");
-    drawInfoLine(lineIndex++, "");
-    drawInfoLine(lineIndex++, "");
   }
 
-  String updateLine = "Updated: ";
-  if (lastSuccessfulFetch > 0) {
-    updateLine += formatTimeAgo(millis() - lastSuccessfulFetch);
-  } else {
-    updateLine += "--";
-  }
   if (aircraftCount > 0) {
-    updateLine += "  Traffic " + String(aircraftCount);
+    String trafficLine = "Traffic: " + String(aircraftCount);
     if (inboundAircraftCount > 0) {
-      updateLine += " (" + String(inboundAircraftCount) + " in)";
+      trafficLine += " (" + String(inboundAircraftCount) + " in)";
     }
+    drawInfoLine(lineIndex++, trafficLine);
   }
-  drawInfoLine(lineIndex++, updateLine);
 
   tft.setTextPadding(0);
   drawRadar();


### PR DESCRIPTION
## Summary
- redesign the static layout so the radar occupies the left half of the display area
- compute radar geometry dynamically and update rendering to use the new layout values
- simplify the information panel to fewer lines and remove the top title banner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc3a1c31088326b7bceca002876c7e