### PR TITLE
Implement dynamic radar contact info table

### DIFF
--- a/freenove.ino
+++ b/freenove.ino
@@ -489,9 +489,10 @@ void renderInfoPanel() {
     if (!flight.length()) {
       flight = String("(Unknown)");
     }
-    headerTitle = "Flight " + flight;
-    headerSubtitle = activeContact->inbound ? String("Inbound alert") : String("Monitoring target");
+    headerTitle = "Active target";
+    headerSubtitle = "";
 
+    addRow("Flight", flight);
     String speedValue = "--";
     if (!isnan(activeContact->groundSpeed) && activeContact->groundSpeed >= 0) {
       speedValue = String(activeContact->groundSpeed, 0) + " kt";
@@ -518,9 +519,10 @@ void renderInfoPanel() {
     if (!flight.length()) {
       flight = String("(unknown)");
     }
-    headerTitle = "Closest " + flight;
-    headerSubtitle = closestAircraft.inbound ? String("Inbound alert") : String("Nearest target");
+    headerTitle = "Closest target";
+    headerSubtitle = "";
 
+    addRow("Flight", flight);
     String speedValue = "--";
     if (!isnan(closestAircraft.groundSpeed) && closestAircraft.groundSpeed >= 0) {
       speedValue = String(closestAircraft.groundSpeed, 0) + " kt";


### PR DESCRIPTION
## Summary
- replace the text-based aircraft info area with a dark blue table layout that highlights key fields
- update radar sweep handling so the panel refreshes with each contact the sweep crosses
- persist extra aircraft metrics (altitude, speed, track, ETA) for display and keep the active highlight consistent across fetches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5f006cc4832686ae105e32592779