### PR TITLE
Add background audio streaming support

### DIFF
--- a/config.h
+++ b/config.h
@@ -18,4 +18,8 @@
 #define I2S_LRCLK_PIN 16
 #define I2S_DOUT_PIN  27
 
+// Audio stream configuration
+#define AUDIO_STREAM_URL "http://192.168.50.4:8000/airband.mp3"
+#define AUDIO_STREAM_VOLUME 18  // Valid range 0 (mute) to 21 (max)
+
 #endif // CONFIG_H

--- a/config.h
+++ b/config.h
@@ -20,6 +20,7 @@
 
 // Audio stream configuration
 #define AUDIO_STREAM_URL "http://192.168.50.4:8000/airband.mp3"
-#define AUDIO_STREAM_VOLUME 18  // Valid range 0 (mute) to 21 (max)
+#define AUDIO_STREAM_VOLUME 18         // Valid range 0 (mute) to 21 (max)
+#define AUDIO_STREAM_BUFFER_SIZE 12288 // Bytes reserved for the streaming input buffer
 
 #endif // CONFIG_H

--- a/config.h
+++ b/config.h
@@ -13,9 +13,9 @@
 #define DUMP1090_SERVER "192.168.50.100" // IP or hostname of dump1090 server
 #define DUMP1090_PORT 8080               // The default web port for dump1090 is often 8080
 
-// I2S pins for MAX98357A audio output
-#define I2S_BCLK_PIN  17
-#define I2S_LRCLK_PIN 16
+// I2S pins for MAX98357A audio output (defaults map to the FNK0103 speaker header)
+#define I2S_BCLK_PIN  26
+#define I2S_LRCLK_PIN 25
 #define I2S_DOUT_PIN  27
 
 // Audio stream configuration

--- a/freenove.ino
+++ b/freenove.ino
@@ -386,20 +386,25 @@ void audio_showstreamtitle(const char *info);
 void audio_eof_mp3(const char *info);
 
 template <typename...>
-using audio_void_t = void;
+struct audio_make_void {
+  using type = void;
+};
+
+template <typename... Ts>
+using audio_detect_void_t = typename audio_make_void<Ts...>::type;
 
 template <typename T, typename = void>
 struct audio_has_msg_t : std::false_type {};
 
 template <typename T>
-struct audio_has_msg_t<T, audio_void_t<typename T::msg_t>> : std::true_type {};
+struct audio_has_msg_t<T, audio_detect_void_t<typename T::msg_t>> : std::true_type {};
 
 template <typename T, typename = void>
 struct audio_has_setAudioInfoCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setAudioInfoCallback<
-    T, audio_void_t<decltype(std::declval<T &>().setAudioInfoCallback(audio_info))>>
+    T, audio_detect_void_t<decltype(std::declval<T &>().setAudioInfoCallback(audio_info))>>
     : std::true_type {};
 
 template <typename T, typename = void>
@@ -407,7 +412,7 @@ struct audio_has_setShowStreamTitleCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setShowStreamTitleCallback<
-    T, audio_void_t<decltype(
+    T, audio_detect_void_t<decltype(
            std::declval<T &>().setShowStreamTitleCallback(audio_showstreamtitle))>>
     : std::true_type {};
 
@@ -416,7 +421,7 @@ struct audio_has_setEofCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setEofCallback<
-    T, audio_void_t<decltype(std::declval<T &>().setEofCallback(audio_eof_mp3))>>
+    T, audio_detect_void_t<decltype(std::declval<T &>().setEofCallback(audio_eof_mp3))>>
     : std::true_type {};
 
 template <typename AudioType>

--- a/freenove.ino
+++ b/freenove.ino
@@ -103,7 +103,10 @@ static const int COMPASS_LABEL_COUNT = 4;
 static const unsigned long AUDIO_RETRY_INTERVAL_MS = 5000;
 static const unsigned long AUDIO_TASK_IDLE_DELAY_MS = 5;
 static const unsigned long AUDIO_RECONNECT_BACKOFF_MS = 1000;
-static const int AUDIO_TASK_STACK_SIZE = 12288;
+static const size_t AUDIO_TASK_STACK_BYTES = 12288;
+static const uint32_t AUDIO_TASK_STACK_SIZE =
+    (AUDIO_TASK_STACK_BYTES + sizeof(StackType_t) - 1) / sizeof(StackType_t);
+static_assert(AUDIO_TASK_STACK_SIZE > 0, "Audio task stack size must be positive");
 static const UBaseType_t AUDIO_TASK_PRIORITY = 2;
 static const BaseType_t AUDIO_TASK_CORE = 0;
 

--- a/freenove.ino
+++ b/freenove.ino
@@ -394,10 +394,10 @@ template <typename... Ts>
 using audio_detect_void_t = typename audio_make_void<Ts...>::type;
 
 template <typename T, typename = void>
-struct audio_has_msg_t : std::false_type {};
+struct audio_player_has_msg_type : std::false_type {};
 
 template <typename T>
-struct audio_has_msg_t<T, audio_detect_void_t<typename T::msg_t>> : std::true_type {};
+struct audio_player_has_msg_type<T, audio_detect_void_t<typename T::msg_t>> : std::true_type {};
 
 template <typename T, typename = void>
 struct audio_has_setAudioInfoCallback : std::false_type {};
@@ -425,7 +425,7 @@ struct audio_has_setEofCallback<
     : std::true_type {};
 
 template <typename AudioType>
-typename std::enable_if<audio_has_msg_t<AudioType>::value>::type
+typename std::enable_if<audio_player_has_msg_type<AudioType>::value>::type
 configureAudioCallbacks(AudioType &player) {
   (void)player;
   AudioType::audio_info_callback = [](typename AudioType::msg_t msg) {
@@ -473,7 +473,7 @@ template <typename AudioType>
 void trySetAudioEofCallback(AudioType &, std::false_type) {}
 
 template <typename AudioType>
-typename std::enable_if<!audio_has_msg_t<AudioType>::value>::type
+typename std::enable_if<!audio_player_has_msg_type<AudioType>::value>::type
 configureAudioCallbacks(AudioType &player) {
   trySetAudioInfoCallback(
       player, std::integral_constant<bool, audio_has_setAudioInfoCallback<AudioType>::value>{});

--- a/freenove.ino
+++ b/freenove.ino
@@ -103,7 +103,7 @@ static const int COMPASS_LABEL_COUNT = 4;
 static const unsigned long AUDIO_RETRY_INTERVAL_MS = 5000;
 static const unsigned long AUDIO_TASK_IDLE_DELAY_MS = 5;
 static const unsigned long AUDIO_RECONNECT_BACKOFF_MS = 1000;
-static const int AUDIO_TASK_STACK_SIZE = 6144;
+static const int AUDIO_TASK_STACK_SIZE = 12288;
 static const UBaseType_t AUDIO_TASK_PRIORITY = 2;
 static const BaseType_t AUDIO_TASK_CORE = 0;
 

--- a/freenove.ino
+++ b/freenove.ino
@@ -7,6 +7,9 @@
 #include <math.h>
 #include <cstring>
 #include <EEPROM.h>
+#ifndef AUDIO_USE_MP3
+#define AUDIO_USE_MP3
+#endif
 #include <Audio.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -388,6 +391,9 @@ void initializeAudioPlayback() {
   audio.setPinout(I2S_BCLK_PIN, I2S_LRCLK_PIN, I2S_DOUT_PIN);
   int volume = constrain((int)AUDIO_STREAM_VOLUME, 0, 21);
   audio.setVolume(volume);
+  audio.setAudioInfoCallback(audio_info);
+  audio.setShowStreamTitleCallback(audio_showstreamtitle);
+  audio.setEofCallback(audio_eof_mp3);
 
   if (audioTaskHandle == nullptr) {
     BaseType_t result = xTaskCreatePinnedToCore(audioStreamTask, "AudioStream", AUDIO_TASK_STACK_SIZE,

--- a/freenove.ino
+++ b/freenove.ino
@@ -386,20 +386,20 @@ void audio_showstreamtitle(const char *info);
 void audio_eof_mp3(const char *info);
 
 template <typename...>
-using void_t = void;
+using audio_void_t = void;
 
 template <typename T, typename = void>
 struct audio_has_msg_t : std::false_type {};
 
 template <typename T>
-struct audio_has_msg_t<T, void_t<typename T::msg_t>> : std::true_type {};
+struct audio_has_msg_t<T, audio_void_t<typename T::msg_t>> : std::true_type {};
 
 template <typename T, typename = void>
 struct audio_has_setAudioInfoCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setAudioInfoCallback<
-    T, void_t<decltype(std::declval<T &>().setAudioInfoCallback(audio_info))>>
+    T, audio_void_t<decltype(std::declval<T &>().setAudioInfoCallback(audio_info))>>
     : std::true_type {};
 
 template <typename T, typename = void>
@@ -407,7 +407,7 @@ struct audio_has_setShowStreamTitleCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setShowStreamTitleCallback<
-    T, void_t<decltype(
+    T, audio_void_t<decltype(
            std::declval<T &>().setShowStreamTitleCallback(audio_showstreamtitle))>>
     : std::true_type {};
 
@@ -416,7 +416,7 @@ struct audio_has_setEofCallback : std::false_type {};
 
 template <typename T>
 struct audio_has_setEofCallback<
-    T, void_t<decltype(std::declval<T &>().setEofCallback(audio_eof_mp3))>>
+    T, audio_void_t<decltype(std::declval<T &>().setEofCallback(audio_eof_mp3))>>
     : std::true_type {};
 
 template <typename AudioType>

--- a/freenove.ino
+++ b/freenove.ino
@@ -440,21 +440,21 @@ struct audio_has_setEofCallback<
 
 template <typename AudioType>
 auto trySetAudioInputBufferSizeImpl(AudioType &player, size_t size, int)
-    -> decltype(player.setInBufferSize(size), bool()) {
+    -> decltype((std::declval<AudioType &>().setInBufferSize(size_t{}), bool())) {
   player.setInBufferSize(size);
   return true;
 }
 
 template <typename AudioType>
 auto trySetAudioInputBufferSizeImpl(AudioType &player, size_t size, long)
-    -> decltype(player.setBufferSize(size), bool()) {
+    -> decltype((std::declval<AudioType &>().setBufferSize(size_t{}), bool())) {
   player.setBufferSize(size);
   return true;
 }
 
 template <typename AudioType>
 auto trySetAudioInputBufferSizeImpl(AudioType &player, size_t size, char)
-    -> decltype(player.inBufferSize = size, bool()) {
+    -> decltype((std::declval<AudioType &>().inBufferSize = size_t{}, bool())) {
   player.inBufferSize = size;
   return true;
 }

--- a/freenove.ino
+++ b/freenove.ino
@@ -425,8 +425,7 @@ struct audio_has_setEofCallback<
     : std::true_type {};
 
 template <typename AudioType>
-typename std::enable_if<audio_player_has_msg_type<AudioType>::value>::type
-configureAudioCallbacks(AudioType &player) {
+void configureAudioCallbacksImpl(AudioType &player, std::true_type) {
   (void)player;
   AudioType::audio_info_callback = [](typename AudioType::msg_t msg) {
     const char *text = msg.msg;
@@ -473,14 +472,18 @@ template <typename AudioType>
 void trySetAudioEofCallback(AudioType &, std::false_type) {}
 
 template <typename AudioType>
-typename std::enable_if<!audio_player_has_msg_type<AudioType>::value>::type
-configureAudioCallbacks(AudioType &player) {
+void configureAudioCallbacksImpl(AudioType &player, std::false_type) {
   trySetAudioInfoCallback(
       player, std::integral_constant<bool, audio_has_setAudioInfoCallback<AudioType>::value>{});
   trySetAudioStreamTitleCallback(
       player, std::integral_constant<bool, audio_has_setShowStreamTitleCallback<AudioType>::value>{});
   trySetAudioEofCallback(
       player, std::integral_constant<bool, audio_has_setEofCallback<AudioType>::value>{});
+}
+
+template <typename AudioType>
+void configureAudioCallbacks(AudioType &player) {
+  configureAudioCallbacksImpl(player, audio_player_has_msg_type<AudioType>{});
 }
 
 void requestAudioRestart() {


### PR DESCRIPTION
## Summary
- add configuration for the built-in speaker stream URL and default volume
- introduce an Audio/I2S playback task pinned to the second core that keeps the MP3 stream running and automatically recovers after Wi-Fi or stream interruptions
- guard touch sampling so sketches still compile when the TFT_eSPI touch controller is not enabled

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32:PartitionScheme=huge_app /tmp/tmp.InJTyVHLz2/ESP32-Radar1090-FNK0103`


------
https://chatgpt.com/codex/tasks/task_e_68d00c955ee88326bf095720b46eed75