### PR TITLE
Add Icecast MP3 streaming support

### DIFF
--- a/config.h
+++ b/config.h
@@ -18,4 +18,8 @@
 #define I2S_LRCLK_PIN 16
 #define I2S_DOUT_PIN  27
 
+// Icecast audio stream configuration
+#define STREAM_URL "http://radio.dylanjones.org:8000/Audacity"
+#define AUDIO_AMP_ENABLE_PIN 4
+
 #endif // CONFIG_H


### PR DESCRIPTION
## Summary
- integrate the ESP8266Audio Icecast MP3 streaming path into the radar sketch with amplifier control and playback lifecycle handling
- extend the touch UI with a stream toggle button and audio status row while wiring the loop to service streaming and WiFi drops
- add configuration for the live Icecast URL and amplifier enable pin used by the FNK0103 hardware

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d186962ed4832684afe11e374ee4d0