### PR TITLE
Keep audio serviced while refreshing info panel

### DIFF
--- a/freenove.ino
+++ b/freenove.ino
@@ -111,6 +111,7 @@ int radarSpriteHeight = 0;
 
 // Forward declarations for helpers referenced before their definitions.
 void invalidateRadarBackground();
+void markInfoPanelDirty();
 
 struct AircraftInfo {
   String flight;


### PR DESCRIPTION
## Summary
- trigger cooperative audio servicing before and during info panel redraws so the decoder keeps running while text rows are updated
- yield back to the audio pipeline between row clears and text draws to reduce stutter during large updates

## Testing
- not run (hardware-dependent project)


------
https://chatgpt.com/codex/tasks/task_e_68d57da1cbf88326b94340111d98716e