### PR TITLE
Document independent radar, audio, and data tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Keep UI rendering and audio streaming responsive; avoid introducing long blocking sections on the loop task when adding new code.
 - Prefer cooperative multitasking helpers (e.g. `vTaskDelay`, `taskYIELD`, or non-blocking waits) when adding work to FreeRTOS tasks so the radar and audio remain smooth.
+- Maintain the separation between the radar render task, the audio streaming task, and the aircraft data fetch task. New work that touches those subsystems should respect their dedicated cores and synchronisation so the three services stay independent.
 - No automated tests are available for this project; if checks cannot be run because they require hardware, note that clearly when reporting results.


### PR DESCRIPTION
## Summary
- highlight in the README the dedicated FreeRTOS tasks for radar rendering, audio streaming, and aircraft data fetching
- update AGENTS guidance to preserve the separation between the three subsystems during future changes

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6e132bfb883268da5d348f547761b