### PR TITLE
Address aircraft fetch memory issues

### DIFF
--- a/freenoveMono.ino
+++ b/freenoveMono.ino
@@ -7,6 +7,7 @@
 #include <SPI.h>
 #include <math.h>
 #include <cstring>
+#include <memory>
 #include <EEPROM.h>
 #include <AudioFileSourceICYStream.h>
 #include <AudioGeneratorMP3.h>
@@ -166,6 +167,8 @@ uint8_t displayRotation = 0;
 uint8_t radarRotationSteps = 0;
 
 bool eepromInitialized = false;
+
+static StaticJsonDocument<16384> aircraftJsonDoc;
 
 struct AirspaceZone {
   const char *name;
@@ -1962,8 +1965,8 @@ void fetchAircraft() {
     return;
   }
 
-  DynamicJsonDocument doc(16384);
-  DeserializationError err = deserializeJson(doc, http.getStream()); // CPU INTENSIVE - NO LOCK HELD
+  aircraftJsonDoc.clear();
+  DeserializationError err = deserializeJson(aircraftJsonDoc, http.getStream()); // CPU INTENSIVE - NO LOCK HELD
   http.end(); // End session immediately after getting data
 
   if (err) {
@@ -1983,7 +1986,17 @@ void fetchAircraft() {
   tempClosestAircraft.track = NAN;
   tempClosestAircraft.minutesToClosest = NAN;
 
-  RadarContact tempContacts[MAX_RADAR_CONTACTS];
+  static std::unique_ptr<RadarContact[]> tempContactsBuffer;
+  static std::unique_ptr<RadarContact[]> previousContactsBuffer;
+
+  if (!tempContactsBuffer) {
+    tempContactsBuffer.reset(new RadarContact[MAX_RADAR_CONTACTS]);
+  }
+  if (!previousContactsBuffer) {
+    previousContactsBuffer.reset(new RadarContact[MAX_RADAR_CONTACTS]);
+  }
+
+  RadarContact *tempContacts = tempContactsBuffer.get();
   int tempContactCount = 0;
   int tempAircraftCount = 0;
   int tempInboundCount = 0;
@@ -1992,7 +2005,7 @@ void fetchAircraft() {
   double alertRangeKm = currentAlertRangeKm();
 
   // Create a snapshot of old data to preserve highlights
-  RadarContact previousContacts[MAX_RADAR_CONTACTS];
+  RadarContact *previousContacts = previousContactsBuffer.get();
   int previousCount;
   int previousActiveIndex;
   String previousActiveFlight; // Use flight name for better tracking
@@ -2004,13 +2017,15 @@ void fetchAircraft() {
     if (activeContactIndex >=0 && activeContactIndex < radarContactCount) {
       previousActiveFlight = radarContacts[activeContactIndex].flight;
     }
-    memcpy(previousContacts, radarContacts, sizeof(radarContacts));
+    for (int i = 0; i < MAX_RADAR_CONTACTS; ++i) {
+      previousContacts[i] = radarContacts[i];
+    }
   }
   bool previousMatched[MAX_RADAR_CONTACTS] = {false};
   int newActiveIndex = -1;
 
   // Main processing loop on the received JSON data
-  JsonArray arr = doc["aircraft"].as<JsonArray>();
+  JsonArray arr = aircraftJsonDoc["aircraft"].as<JsonArray>();
   for (JsonObject plane : arr) {
     serviceAudioDecoder(); // Yield to let audio buffer fill
     
@@ -2178,7 +2193,9 @@ void fetchAircraft() {
     lastSuccessfulFetch = now;
     
     // Copy temporary data to the global structures
-    memcpy(radarContacts, tempContacts, sizeof(tempContacts));
+    for (int i = 0; i < tempContactCount; ++i) {
+      radarContacts[i] = tempContacts[i];
+    }
     radarContactCount = tempContactCount;
     
     // Invalidate any remaining slots


### PR DESCRIPTION
## Summary
- reuse a static JSON document when parsing aircraft data to prevent repeated heap allocations
- move large RadarContact working buffers from the stack to heap-backed storage managed with unique_ptr
- replace raw memcpy copies of RadarContact arrays with safe element-wise assignments to avoid String corruption

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68d7a07cdb14832690b4fb89bc0f7c9d